### PR TITLE
partial naming

### DIFF
--- a/lib/hamlbars/template.rb
+++ b/lib/hamlbars/template.rb
@@ -80,13 +80,23 @@ module Hamlbars
                  else
                    @engine.render(scope, locals, &block)
                  end
-      if basename =~ /^_/
-        "#{self.class.template_partial_method}('#{name}', '#{template.strip.gsub(/(\r\n|[\n\r"'])/) { JS_ESCAPE_MAP[$1] }}');\n"
-      elsif scope.respond_to? :logical_path
-        "#{self.class.template_destination}[\"#{self.class.path_translator(scope.logical_path)}\"] = #{self.class.template_compiler}(\"#{template.strip.gsub(/(\r\n|[\n\r"'])/) { JS_ESCAPE_MAP[$1] }}\");\n"
+      if scope.respond_to? :logical_path
+        name = self.class.path_translator(scope.logical_path)
       else
-        "#{self.class.template_destination}[\"#{self.class.path_translator(basename)}\"] = #{self.class.template_compiler}(\"#{template.strip.gsub(/(\r\n|[\n\r"'])/) { JS_ESCAPE_MAP[$1] }}\");\n"
+        name = self.class.path_translator(basename)
       end
+
+      if basename =~ /^_/
+        name = remove_underscore_from_partial_name(name, basename)
+        "#{self.class.template_partial_method}('#{name}', '#{template.strip.gsub(/(\r\n|[\n\r"'])/) { JS_ESCAPE_MAP[$1] }}');\n"
+      else
+        "#{self.class.template_destination}[\"#{name}\"] = #{self.class.template_compiler}(\"#{template.strip.gsub(/(\r\n|[\n\r"'])/) { JS_ESCAPE_MAP[$1] }}\");\n"
+      end
+    end
+
+    def remove_underscore_from_partial_name(name, basename)
+      translated_basename = self.class.path_translator(basename)
+      name.sub(/#{translated_basename}$/, translated_basename[1..-1])
     end
 
     # Precompiled Haml source. Taken from the precompiled_with_ambles

--- a/spec/template_spec.rb
+++ b/spec/template_spec.rb
@@ -128,3 +128,26 @@ EOF
   end
 
 end
+
+describe Hamlbars::Template, "partials" do
+
+  let(:template_file) { Tempfile.new '_hamlbars_template' }
+
+  before :each do
+    template_file.rewind
+  end
+
+  after :each do
+    template_file.flush
+  end
+
+  after :all do
+    template_file.unlink
+  end
+
+  it "should render partial preamble" do
+    template = Hamlbars::Template.new(template_file)
+
+    template.render.should == "Handlebars.registerPartial('#{File.basename(template_file.path)}', \'\');\n"
+  end
+end

--- a/spec/template_spec.rb
+++ b/spec/template_spec.rb
@@ -148,6 +148,8 @@ describe Hamlbars::Template, "partials" do
   it "should render partial preamble" do
     template = Hamlbars::Template.new(template_file)
 
-    template.render.should == "Handlebars.registerPartial('#{File.basename(template_file.path)}', \'\');\n"
+    basename = File.basename(template_file.path)
+    partial_name = Hamlbars::Template.path_translator(basename)[1..-1]
+    template.render.should == "Handlebars.registerPartial('#{partial_name}', \'\');\n"
   end
 end


### PR DESCRIPTION
Right now partials are just named after the basename, including the `_`. This means we have to do `{{> _pager }}`. I wonder if we should strip the _? Furthermore, what if we allowed partials to be named based on their directory hierarchy like views are: `shared_pager` if it's in `shared/_pager`. Thoughts?
