### PR TITLE
Don't replace / or make it optional

### DIFF
--- a/lib/hamlbars/template.rb
+++ b/lib/hamlbars/template.rb
@@ -80,13 +80,23 @@ module Hamlbars
                  else
                    @engine.render(scope, locals, &block)
                  end
-      if basename =~ /^_/
-        "#{self.class.template_partial_method}('#{name}', '#{template.strip.gsub(/(\r\n|[\n\r"'])/) { JS_ESCAPE_MAP[$1] }}');\n"
-      elsif scope.respond_to? :logical_path
-        "#{self.class.template_destination}[\"#{self.class.path_translator(scope.logical_path)}\"] = #{self.class.template_compiler}(\"#{template.strip.gsub(/(\r\n|[\n\r"'])/) { JS_ESCAPE_MAP[$1] }}\");\n"
+      if scope.respond_to? :logical_path
+        name = self.class.path_translator(scope.logical_path)
       else
-        "#{self.class.template_destination}[\"#{self.class.path_translator(basename)}\"] = #{self.class.template_compiler}(\"#{template.strip.gsub(/(\r\n|[\n\r"'])/) { JS_ESCAPE_MAP[$1] }}\");\n"
+        name = self.class.path_translator(basename)
       end
+
+      if basename =~ /^_/
+        name = remove_underscore_from_partial_name(name, basename)
+        "#{self.class.template_partial_method}('#{name}', '#{template.strip.gsub(/(\r\n|[\n\r"'])/) { JS_ESCAPE_MAP[$1] }}');\n"
+      else
+        "#{self.class.template_destination}[\"#{name}\"] = #{self.class.template_compiler}(\"#{template.strip.gsub(/(\r\n|[\n\r"'])/) { JS_ESCAPE_MAP[$1] }}\");\n"
+      end
+    end
+
+    def remove_underscore_from_partial_name(name, basename)
+      translated_basename = self.class.path_translator(basename)
+      name.sub(/#{translated_basename}$/, translated_basename[1..-1])
     end
 
     # Precompiled Haml source. Taken from the precompiled_with_ambles

--- a/spec/template_spec.rb
+++ b/spec/template_spec.rb
@@ -132,6 +132,7 @@ end
 describe Hamlbars::Template, "partials" do
 
   let(:template_file) { Tempfile.new '_hamlbars_template' }
+  let(:template) { Hamlbars::Template.new(template_file) }
 
   before :each do
     template_file.rewind
@@ -146,10 +147,19 @@ describe Hamlbars::Template, "partials" do
   end
 
   it "should render partial preamble" do
-    template = Hamlbars::Template.new(template_file)
-
     basename = File.basename(template_file.path)
-    partial_name = Hamlbars::Template.path_translator(basename)[1..-1]
+    partial_name = basename.gsub(/-/, '_')[1..-1]
     template.render.should == "Handlebars.registerPartial('#{partial_name}', \'\');\n"
+  end
+
+  it "should replace everything but letters, numbers with _ and / with ." do
+    template.stub(:basename) { "_asdf1234,%*/." }
+    template.partial_path_translator("asdf1234,%*/.").should == "asdf1234___._"
+  end
+end
+
+describe Hamlbars::Template, "#path_translator" do
+  it "should replace everything but letters, numbers and slashes with _" do
+    Hamlbars::Template.path_translator("asdf1234,%*/.").should == "asdf1234___/_"
   end
 end

--- a/spec/template_spec.rb
+++ b/spec/template_spec.rb
@@ -128,3 +128,26 @@ EOF
   end
 
 end
+
+describe Hamlbars::Template, "partials" do
+
+  let(:template_file) { Tempfile.new '_hamlbars_template' }
+
+  before :each do
+    template_file.rewind
+  end
+
+  after :each do
+    template_file.flush
+  end
+
+  after :all do
+    template_file.unlink
+  end
+
+  it "should render partial preamble" do
+    template = Hamlbars::Template.new(template_file)
+
+    template.render.should == "Handlebars.registerPartial('#{File.basename(template_file.path)}', \'\');\n"
+  end
+end

--- a/spec/template_spec.rb
+++ b/spec/template_spec.rb
@@ -148,6 +148,8 @@ describe Hamlbars::Template, "partials" do
   it "should render partial preamble" do
     template = Hamlbars::Template.new(template_file)
 
-    template.render.should == "Handlebars.registerPartial('#{File.basename(template_file.path)}', \'\');\n"
+    basename = File.basename(template_file.path)
+    partial_name = Hamlbars::Template.path_translator(basename)[1..-1]
+    template.render.should == "Handlebars.registerPartial('#{partial_name}', \'\');\n"
   end
 end


### PR DESCRIPTION
The other hamlbars gem doesn't replace / with _, so templates still "hold" to their folder structure. I rather like this, but it would be a breaking change. What would you think about making it the default or at least making it optional? I could override it easily by overriding Hamlbars::Template.path_translator, but just wanted to see what you thought about it.
