### PR TITLE
Better handling of `hb 'else' do` blocks

### DIFF
--- a/lib/hamlbars/template.rb
+++ b/lib/hamlbars/template.rb
@@ -191,7 +191,10 @@ module Haml
       def express(demarcation,expression,options={},&block)
         if block.respond_to? :call
           content = capture_haml(&block)
-          output = "#{demarcation.first}##{make(expression, options)}#{demarcation.last}#{content.strip}#{demarcation.first}/#{expression.split(' ').first}#{demarcation.last}"
+          output = "#{demarcation.first}##{make(expression, options)}#{demarcation.last}#{content.strip}"
+          if expression != "else"
+            output << "#{demarcation.first}/#{expression.split(' ').first}#{demarcation.last}"
+          end
         else
           output = "#{demarcation.first}#{make(expression, options)}#{demarcation.last}"
         end

--- a/spec/template_spec.rb
+++ b/spec/template_spec.rb
@@ -102,6 +102,19 @@ EOF
     template.render.should == "Handlebars.templates[\"#{Hamlbars::Template.path_translator(File.basename(template_file.path))}\"] = Handlebars.compile(\"{{#if a_thing_is_true}}{{hello}}\\n<a {{bindAttr href=\\\"aController\\\"}}></a>{{/if}}\");\n"
   end
 
+  it "should not close else contents" do
+    template_file.write <<EOF
+= hb 'if a_thing_is_true' do
+  Hello
+  = hb 'else' do
+    Goodbye
+EOF
+    template_file.rewind
+    template = Hamlbars::Template.new(template_file)
+    template.render.should == "Handlebars.templates[\"#{Hamlbars::Template.path_translator(File.basename(template_file.path))}\"] = Handlebars.compile(\"{{#if a_thing_is_true}}Hello\\n{{#else}}Goodbye{{/if}}\");\n"
+
+  end
+
   it "should not mark expressions as html_safe when XSS protection is disabled" do
     Haml::Util.module_eval do
       def rails_xss_safe?


### PR DESCRIPTION
An idea on using 'else' blocks with hamlbars.

https://gist.github.com/2992040

I personally think its way more readable when I can indent my else blocks. E.g. 

```
= hb 'if content.condition1' do
  = hb 'if content.condition2' do
    %p Some paragraph
    = hb 'else' do
      %p another paragraph
  = hb 'else' do
    %p third paragraph
```

Let me know what you think. If you think this implementation is too hacky, and alternative would be to create a new helper `hb_else` that takes a block.
