### PR TITLE
fix up Haml::Compiler extension so it works on both Haml 3.1 and 3.2

### DIFF
--- a/lib/hamlbars/ext/compiler.rb
+++ b/lib/hamlbars/ext/compiler.rb
@@ -1,44 +1,58 @@
 module Hamlbars
   module Ext
     module Compiler
-    end
-  end
-end
-
-module Haml
-  module Compiler
-
-    class << self
-      # Overload build_attributes in Haml::Compiler to allow
-      # for the creation of handlebars bound attributes by
-      # adding :bind hash to the tag attributes.
-      def build_attributes_with_handlebars_attributes (is_html, attr_wrapper, escape_attrs, attributes={})
-        attributes[:bind] = attributes.delete('bind') if attributes['bind']
-        attributes[:event] = attributes.delete('event') if attributes['event']
-        attributes[:events] = attributes.delete('events') if attributes['events']
-        attributes[:events] ||= []
-        attributes[:events] << attributes.delete(:event) if attributes[:event]
-
-        handlebars_rendered_attributes = []
-        handlebars_rendered_attributes << handlebars_attributes('bindAttr', attributes.delete(:bind)) if attributes[:bind]
-        attributes[:events].each do |event|
-          event[:on] = event.delete('on') || event.delete(:on) || 'click'
-          action = event.delete('action') || event.delete(:action)
-          handlebars_rendered_attributes << handlebars_attributes("action \"#{action}\"", event)
-        end
-        attributes.delete(:events)
-
-        (handlebars_rendered_attributes * '') +
-          build_attributes_without_handlebars_attributes(is_html, attr_wrapper, escape_attrs, attributes)
-      end
-      alias build_attributes_without_handlebars_attributes build_attributes
-      alias build_attributes build_attributes_with_handlebars_attributes 
-
-      private
-
-      def handlebars_attributes(helper, attributes)
+      def self.handlebars_attributes(helper, attributes)
         rendered_attributes = [].tap { |r|attributes.each { |k,v| r << "#{k}=\"#{v}\"" } }.join(' ')
         " {{#{helper} #{rendered_attributes}}}"
+      end
+
+      def self.included(base)
+        base.instance_eval do
+
+          if Haml::VERSION >= "3.2"
+            # Haml 3.2 introduces hyphenate_data_attrs
+            def build_attributes_with_handlebars_attributes (is_html, attr_wrapper, escape_attrs, hyphenate_data_attrs, attributes={})
+              handlebars_rendered_attributes = build_attributes_with_handlebars_attributes_base(is_html, attr_wrapper, escape_attrs, attributes)
+
+              (handlebars_rendered_attributes * '') +
+                build_attributes_without_handlebars_attributes(is_html, attr_wrapper, escape_attrs, hyphenate_data_attrs, attributes)
+            end
+          else
+            def build_attributes_with_handlebars_attributes (is_html, attr_wrapper, escape_attrs, attributes={})
+              handlebars_rendered_attributes = build_attributes_with_handlebars_attributes_base(is_html, attr_wrapper, escape_attrs, attributes)
+
+              (handlebars_rendered_attributes * '') +
+                build_attributes_without_handlebars_attributes(is_html, attr_wrapper, escape_attrs, attributes)
+            end
+          end
+
+          # Overload build_attributes in Haml::Compiler to allow
+          # for the creation of handlebars bound attributes by
+          # adding :bind hash to the tag attributes.
+          def build_attributes_with_handlebars_attributes_base(is_html, attr_wrapper, escape_attrs, attributes={})
+            attributes[:bind] = attributes.delete('bind') if attributes['bind']
+            attributes[:event] = attributes.delete('event') if attributes['event']
+            attributes[:events] = attributes.delete('events') if attributes['events']
+            attributes[:events] ||= []
+            attributes[:events] << attributes.delete(:event) if attributes[:event]
+
+            handlebars_rendered_attributes = []
+            handlebars_rendered_attributes << Hamlbars::Ext::Compiler.handlebars_attributes('bindAttr', attributes.delete(:bind)) if attributes[:bind]
+            attributes[:events].each do |event|
+              event[:on] = event.delete('on') || event.delete(:on) || 'click'
+              action = event.delete('action') || event.delete(:action)
+              handlebars_rendered_attributes << Hamlbars::Ext::Compiler.handlebars_attributes("action \"#{action}\"", event)
+            end
+            attributes.delete(:events)
+
+            handlebars_rendered_attributes
+          end
+
+
+          alias build_attributes_without_handlebars_attributes build_attributes
+          alias build_attributes build_attributes_with_handlebars_attributes
+
+        end
       end
     end
   end

--- a/spec/template_spec.rb
+++ b/spec/template_spec.rb
@@ -31,7 +31,7 @@ describe Hamlbars::Template do
   it "should bind element attributes" do
     template_file.write('%img{ :bind => { :src => "logoUri" }, :alt => "Logo" }')
     template_file.rewind
-    template = Hamlbars::Template.new(template_file)
+    template = Hamlbars::Template.new(template_file, :format => :xhtml)
     template.render.should == "Handlebars.templates[\"#{Hamlbars::Template.path_translator(File.basename(template_file.path))}\"] = Handlebars.compile(\"<img {{bindAttr src=\\\"logoUri\\\"}} alt=\\'Logo\\' />\");\n"
   end
 


### PR DESCRIPTION
Allows hamlbars to work on both Haml 3.1 and 3.2
