### PR TITLE
Add Heroku tip related to ember-rails initializer to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,7 +179,14 @@ The good news is that if you're using the
 automatically detect hamlbars and change it for you. Magic!
 
 If you're using [ember-rails](http://rubygems.org/gems/ember-rails) then you'll
-need to put this in a initializer.
+need to put this in a initializer. When deploying to Heroku, making sure `Hamlbars` is defined [can be helpful][ember-rails-heroku-tip-source]:
+
+```ruby
+if defined? Hamlbars
+  Hamlbars::Template.render_templates_for :ember
+end
+```
+  [ember-rails-heroku-tip-source]: https://github.com/jamesotron/HamlbarsDemo/blob/master/config/initializers/hamlbars.rb
 
 # Configuring JavaScript output:
 


### PR DESCRIPTION
I ran into an `undefined constant Hamlbars` exception when deploying to Heroku which was related to `config/initializers/hamlbars.rb`.
I am using [ember-rails](http://rubygems.org/gems/ember-rails)  and was following the [corresponding README section](https://github.com/jamesotron/hamlbars#configuring-template-output).

The [solution](https://github.com/jamesotron/HamlbarsDemo/blob/master/config/initializers/hamlbars.rb) to that issue is available in the demo application. IMHO, given there is a mention to _ember-rails_ in the README, it would be worth mentioning the tip.
