### PR TITLE
Updated depcrecated bindAttr

### DIFF
--- a/lib/hamlbars/ext/compiler.rb
+++ b/lib/hamlbars/ext/compiler.rb
@@ -33,7 +33,7 @@ module Hamlbars
             handlebars_rendered_attributes = []
 
             if bind = attributes.delete('bind')
-              handlebars_rendered_attributes << Hamlbars::Ext::Compiler.handlebars_attributes('bindAttr', bind)
+              handlebars_rendered_attributes << Hamlbars::Ext::Compiler.handlebars_attributes('bind-attr', bind)
             end
 
             if hb = attributes.delete('hb')

--- a/lib/hamlbars/version.rb
+++ b/lib/hamlbars/version.rb
@@ -1,3 +1,3 @@
 module Hamlbars
-  VERSION = '2.0.1'
+  VERSION = '2.0.2'
 end

--- a/spec/template_spec.rb
+++ b/spec/template_spec.rb
@@ -31,7 +31,7 @@ describe Hamlbars::Template do
 
   it "should bind element attributes" do
     to_handlebars('%img{ :bind => { :src => "logoUri" }, :alt => "Logo" }').should ==
-      "<img {{bindAttr src=\"logoUri\"}} alt=\'Logo\' />"
+      "<img {{bind-attr src=\"logoUri\"}} alt=\'Logo\' />"
   end
 
   it "should render action attributes" do
@@ -85,7 +85,7 @@ describe Hamlbars::Template do
   = hb 'hello'
   %a{:bind => {:href => 'aController'}}
 EOF
-    handlebars.should == "{{#if a_thing_is_true}}{{hello}}\n<a {{bindAttr href=\"aController\"}}></a>{{/if}}"
+    handlebars.should == "{{#if a_thing_is_true}}{{hello}}\n<a {{bind-attr href=\"aController\"}}></a>{{/if}}"
   end
 
   it "should not mark expressions as html_safe when XSS protection is disabled" do


### PR DESCRIPTION
Latest versions of Ember are flagging bindAttr as deprecated.  This updates hamlbars to generate bind-attr instead
