### PR TITLE
Use quoted action name.

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,8 +180,8 @@ To use Ember's `{{action}}` helper, set the `:_action` attribute, like so:
 This will generate:
 
 ```html
-<a {{action toggle}}>Toggle</a>
-<a {{action edit article on="doubleClick"}}>Edit</a>
+<a {{action "toggle"}}>Toggle</a>
+<a {{action "edit" article on="doubleClick"}}>Edit</a>
 ```
 
 Note that `:_action` has a leading underscore, to distinguish it from regular

--- a/hamlbars.gemspec
+++ b/hamlbars.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |s|
   s.summary       = 'Extensions to Haml to allow creation of handlebars expressions.'
   s.description   = 'Hamlbars allows you to write handlebars templates using the familiar Haml syntax.'
   s.add_dependency 'haml'
-  s.add_dependency 'sprockets'
+  s.add_dependency 'sprockets', '>= 2.0'
   s.add_dependency 'tilt'
   s.add_dependency 'execjs', [">= 1.2"]
   s.add_development_dependency 'rake'

--- a/lib/hamlbars/ext/compiler.rb
+++ b/lib/hamlbars/ext/compiler.rb
@@ -45,7 +45,8 @@ module Hamlbars
             # This could be generalized into /_.*/ catch-all syntax, if
             # necessary. https://github.com/jamesotron/hamlbars/pull/33
             if action = attributes.delete('_action')
-              handlebars_rendered_attributes << " {{action #{action}}}"
+              actionName, rest = action.split(/\s/, 2)
+              handlebars_rendered_attributes << " {{action \"#{actionName}\" #{rest}}}"
             end
 
             handlebars_rendered_attributes

--- a/spec/template_spec.rb
+++ b/spec/template_spec.rb
@@ -36,7 +36,7 @@ describe Hamlbars::Template do
 
   it "should render action attributes" do
     to_handlebars('%a{ :_action => \'edit article on="click"\' } Edit').should ==
-      '<a {{action edit article on="click"}}>Edit</a>'
+      '<a {{action "edit" article on="click"}}>Edit</a>'
   end
 
   it "should render in-tag expressions" do


### PR DESCRIPTION
As of Ember 1.4.0-beta.5 using the unquoted version is deprecated. Using a
quoted string is totally backwards compatible so this is a non-breaking
change.

Ember 1.5.0 will use unquoted action names and performed property lookup,
allowing for dynamic actions. We will have to decide how to handle these
dynamic action names at some point
(likely after 1.5.0 ships).

For Reference:

https://github.com/emberjs/ember.js/pull/3936
https://github.com/emberjs/ember.js/pull/4276
https://github.com/emberjs/ember.js/commit/2ef00a2acd80a9b6daea3510b6cd8774751d9dfb

---

I also pinned the Sprockets dependency to `>= 2.0.0` which was the first version with `Sprockets.register_engine` (around 2 years ago). Apparently, I had a super old version locally, and could not run the specs.
