### PR TITLE
Rails engine check

### DIFF
--- a/lib/hamlbars.rb
+++ b/lib/hamlbars.rb
@@ -3,7 +3,7 @@ require 'sprockets'
 
 module Hamlbars
 
-  if defined? Rails
+  if defined? Rails::Engine
     class Engine < Rails::Engine
     end
   end

--- a/lib/hamlbars/ext/rails_helper.rb
+++ b/lib/hamlbars/ext/rails_helper.rb
@@ -10,7 +10,7 @@ module Hamlbars
         scope = scope.dup
 
         scope.class.send(:include, ActionView::Helpers) if defined?(::ActionView)
-        if defined?(::Rails)
+        if defined?(::Rails.application)
           scope.class.send(:include, Rails.application.helpers)
           scope.class.send(:include, Rails.application.routes.url_helpers)
           scope.default_url_options = Rails.application.config.action_controller.default_url_options || {}


### PR DESCRIPTION
Checks for `Rails::Engine` and `Rails.application` instead of just `Rails` in a couple of places.

Does what #45 would have done if it hadn't gotten closed without getting merged.
