### PR TITLE
Add `bin/hamlbars` command

### DIFF
--- a/bin/hamlbars
+++ b/bin/hamlbars
@@ -1,0 +1,17 @@
+#!/usr/bin/env ruby
+
+require 'sprockets'
+require 'tilt'
+require 'hamlbars'
+
+Tilt.register Hamlbars::Template, 'hamlbars'
+
+input  = ARGV.first
+
+template = Tilt['hamlbars'].new(input) {
+  File.read(input)
+}
+
+output = template.render(self)
+
+$stdout.write(output)

--- a/hamlbars.gemspec
+++ b/hamlbars.gemspec
@@ -19,7 +19,9 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'rspec', ["~> 3.0"]
   s.add_development_dependency 'activesupport'
 
-  s.files         = %w(README.md History.md MIT-LICENSE) + Dir["lib/**/*"] + Dir["vendor/**/*"]
+  s.files         = %w(README.md History.md MIT-LICENSE) + Dir["lib/**/*"] + Dir["vendor/**/*"] + Dir["bin/**/*"]
+  s.bindir        = 'bin'
+  s.executables   = s.files.grep(%r{^bin/}) { |f| File.basename(f) }
 
   s.require_paths = ['lib']
 end


### PR DESCRIPTION
Hi @jamesotron,

I would like to add `bin/hamlbars` command as a utility.
This is similar to https://github.com/jamesotron/hamlbars/issues/66.

Original script is taken from https://github.com/hrysd/grunt-hamlbars, created by @hrysd.
(I opened pull request https://github.com/hrysd/grunt-hamlbars/pull/5 ages ago)
