### PR TITLE
Silence deprecation warnings for Sprockets

### DIFF
--- a/lib/hamlbars.rb
+++ b/lib/hamlbars.rb
@@ -16,8 +16,7 @@ module Hamlbars
   Haml::Compiler.send(:include, Ext::Compiler)
 
   if defined? Sprockets
-    Sprockets.register_mime_type 'text/haml', extensions: ['.hamlbars']
-    Sprockets.register_preprocessor 'text/haml', Template
+    Sprockets.register_engine '.hamlbars', Template, silence_deprecation: true
   end
 
 end

--- a/lib/hamlbars.rb
+++ b/lib/hamlbars.rb
@@ -16,7 +16,8 @@ module Hamlbars
   Haml::Compiler.send(:include, Ext::Compiler)
 
   if defined? Sprockets
-    Sprockets.register_engine '.hamlbars', Template
+    Sprockets.register_mime_type 'text/haml', extensions: ['.hamlbars']
+    Sprockets.register_preprocessor 'text/haml', Template
   end
 
 end

--- a/lib/hamlbars/version.rb
+++ b/lib/hamlbars/version.rb
@@ -1,3 +1,3 @@
 module Hamlbars
-  VERSION = '3.1.1'
+  VERSION = '2.1.1'
 end

--- a/lib/hamlbars/version.rb
+++ b/lib/hamlbars/version.rb
@@ -1,3 +1,3 @@
 module Hamlbars
-  VERSION = '2.1.1'
+  VERSION = '3.1.1'
 end


### PR DESCRIPTION
Sprockets will spam logs with this warning (see #72 too):

```
DEPRECATION WARNING: Sprockets method `register_engine` is deprecated.
Please register a mime type using `register_mime_type` then
use `register_compressor` or `register_transformer`.
https://github.com/rails/sprockets/blob/master/guides/extending_sprockets.md#supporting-all-versions-of-sprockets-in-processors
```

This is a super quick fix to silence that, since adding fully Sprockets v4 compatibility requires a little extra work.